### PR TITLE
feat: added bundle option to the config

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -71,6 +71,8 @@ export const buildConfigSchema = Type.RecordOf({
       Type.Literal("legacy")
     )
   ),
+  entrypoint: OptionalField(Type.String),
+  bundle: OptionalField(Type.Boolean),
   tsConfig: OptionalField(Type.String),
   declarations: OptionalField(Type.OneOf(Type.Boolean, Type.Literal("only"))),
   exclude: OptionalField(
@@ -246,6 +248,14 @@ buildConfigSchema.recordOf.replaceImports.type
   .setDescription(
     "A map of import paths/packages that should be replaced with another import."
   );
+
+buildConfigSchema.recordOf.bundle.type.setDescription(
+  `
+When enabled, the entire program will be bundled into a single file, 
+with the exception of files and packages marked as external or as vendors.
+
+\`entrypoint\` option must be provided when \`bundle\` is enabled.`
+);
 
 export const validateBuildConfig = (config: BuildConfig) => {
   const validate = createValidatedFunction(

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -74,7 +74,8 @@ export class Builder {
     originalFilePath: string,
     outDir: string,
     format: esbuild.BuildOptions["format"],
-    ext: string
+    ext: string,
+    bundle = false
   ) {
     const {
       plugins: additionalPlugins = [],
@@ -113,6 +114,7 @@ export class Builder {
           outDir,
           outfile,
           outExt,
+          bundle,
         }),
       ],
       outExtension: { ".js": outExt },
@@ -137,6 +139,45 @@ export class Builder {
     }
 
     return filePath;
+  }
+
+  async bundle(filePath: string, format: "cjs" | "esm" | "legacy") {
+    const isomorphicPath = this.resolveIsomorphicImport(filePath, format);
+
+    if (format === "cjs") {
+      return this.buildFile(
+        isomorphicPath,
+        filePath,
+        this.cjsBuildDir,
+        "cjs",
+        ".cjs",
+        true
+      );
+    }
+
+    if (format === "esm") {
+      return this.buildFile(
+        isomorphicPath,
+        filePath,
+        this.esmBuildDir,
+        "esm",
+        ".mjs",
+        true
+      );
+    }
+
+    if (format === "legacy") {
+      return this.buildFile(
+        isomorphicPath,
+        filePath,
+        this.legacyBuildDir,
+        "cjs",
+        ".js",
+        true
+      );
+    }
+
+    throw Error("Impossible scenario.");
   }
 
   async build(filePath: string, format: "cjs" | "esm" | "legacy") {
@@ -246,6 +287,7 @@ export class Builder {
           outDir,
           outfile,
           outExt,
+          bundle: false,
         }),
       ],
       outExtension: { ".js": outExt },

--- a/src/utilities/is-real-path.ts
+++ b/src/utilities/is-real-path.ts
@@ -4,7 +4,7 @@ import { CacheMap } from "./info-cache";
 
 const resultCache = new CacheMap<boolean>();
 
-export const isRealPath = async (path: string) => {
+export const fileExists = async (path: string) => {
   const cachedResult = resultCache.get(path);
   if (cachedResult !== undefined) {
     return cachedResult;


### PR DESCRIPTION
When this new option is enabled, and an entry-point is provided, instead of compiling all the files separately, bundles for each format will be generated.

An exception to this are imports marked as external, as well as disparately compiled vendors.