### PR TITLE
fix: import resolution for vendor packages

### DIFF
--- a/src/utilities/vendor-builder-plugin.ts
+++ b/src/utilities/vendor-builder-plugin.ts
@@ -74,11 +74,25 @@ export const VendorBuilderPlugin = (params: {
           };
         }
 
-        return {
-          path: path.isAbsolute(args.path)
-            ? args.path
-            : path.resolve(args.resolveDir, args.path),
-        };
+        if (args.path === originalPath) {
+          return;
+        }
+
+        if (!args.path.startsWith(".") || args.path.startsWith("/")) {
+          return {
+            path: path.isAbsolute(args.path)
+              ? args.path
+              : path.resolve(args.resolveDir, args.path),
+          };
+        }
+
+        return build.resolve(args.path, {
+          importer: args.importer,
+          kind: args.kind,
+          namespace: args.namespace,
+          resolveDir: args.resolveDir,
+          pluginData: args.pluginData,
+        });
       });
     },
   };


### PR DESCRIPTION
Fixed an issue with import resolution for vendor packages. Every import within vendors was treated as a filesystem path unless marked as external or the `compileVendors` option was set to `all`. This meant that if a vendor was importing a package from `node_modules` the vendor compilation would fail.