### PR TITLE
feat: adding banner and footers to individual compiled files

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -33,6 +33,25 @@ const TypeExtensionMap = Type.Custom(isValidExtMapping).setExtra({
   type: 'Record<`.${string}`, `.${string}` | "%FORMAT%">',
 });
 
+const TypeBannerFooterLoader = Type.OneOf(
+  Type.Literal("esbuild"),
+  Type.Literal("typescript"),
+  Type.Literal("copy")
+);
+
+const TypeBannerFooterMap = Type.Dict(
+  Type.OneOf(
+    Type.RecordOf({
+      file: Type.String,
+      loader: OptionalField(TypeBannerFooterLoader),
+    }),
+    Type.RecordOf({
+      text: Type.String,
+      loader: OptionalField(TypeBannerFooterLoader),
+    })
+  )
+);
+
 export const buildConfigSchema = Type.RecordOf({
   target: Type.OneOf(
     Type.Literal("es2015"),
@@ -107,6 +126,8 @@ export const buildConfigSchema = Type.RecordOf({
       gjs: OptionalField(Type.Boolean),
     })
   ),
+  banner: OptionalField(TypeBannerFooterMap),
+  footer: OptionalField(TypeBannerFooterMap),
 });
 
 buildConfigSchema.setTitle("BuildConfig");
@@ -270,6 +291,10 @@ with the exception of files and packages marked as external or as vendors.
 
 buildConfigSchema.recordOf.preset.type.recordOf.node.type.setDescription(
   "When enabled all the packages provided by the Node environment will be added to the `external` array."
+);
+
+TypeBannerFooterMap.setDescription(
+  "A map of filename regex patterns to text or files that ought to be appended or prepended to them at the build time."
 );
 
 export const validateBuildConfig = (config: BuildConfig) => {

--- a/src/utilities/config-helper.ts
+++ b/src/utilities/config-helper.ts
@@ -4,6 +4,8 @@ import { denoPreset } from "./presets/deno.preset";
 import { gjsPreset } from "./presets/gjs.preset";
 import { nodePreset } from "./presets/node.preset";
 
+export type FooterBanner = ValueOf<Defined<BuildConfig["banner"]>>;
+
 type MergeWithCustomizer = {
   bivariantHack(
     value: any,
@@ -15,6 +17,8 @@ type MergeWithCustomizer = {
 }["bivariantHack"];
 
 type Defined<T> = Exclude<T, undefined | null>;
+
+type ValueOf<T extends object> = T[keyof T];
 
 export class ConfigHelper {
   vendors = new Set<string>();
@@ -82,6 +86,34 @@ export class ConfigHelper {
     }
 
     return false;
+  }
+
+  getFooterBanner(file: string) {
+    const bannerMap = this.config.banner ?? {};
+    const footerMap = this.config.footer ?? {};
+    const bannerKeys = Object.keys(bannerMap);
+    const footerKeys = Object.keys(footerMap);
+
+    const result = {
+      banner: null as null | FooterBanner,
+      footer: null as null | FooterBanner,
+    };
+
+    for (const bannerKey of bannerKeys) {
+      const regexp = new RegExp(bannerKey);
+      if (regexp.test(file)) {
+        result.banner = bannerMap[bannerKey]!;
+      }
+    }
+
+    for (const footerKey of footerKeys) {
+      const regexp = new RegExp(footerKey);
+      if (regexp.test(file)) {
+        result.footer = footerMap[footerKey]!;
+      }
+    }
+
+    return result;
   }
 
   get<K extends keyof BuildConfig>(configProperty: K): BuildConfig[K];

--- a/src/utilities/load-footer-banner.ts
+++ b/src/utilities/load-footer-banner.ts
@@ -1,0 +1,70 @@
+import type { ts } from "@ts-morph/bootstrap";
+import esbuild from "esbuild";
+import { readFile } from "fs/promises";
+import path from "path";
+import type { ProgramContext } from "../program";
+import type { FooterBanner } from "./config-helper";
+
+export const loadFooterBanner = async (
+  program: ProgramContext,
+  format: esbuild.BuildOptions["format"],
+  footerBanner: FooterBanner
+) => {
+  const tsOptions: Partial<ts.CompilerOptions> = {
+    target: 2, // ES2015
+    experimentalDecorators: program.config.get("decoratorsMetadata", false),
+    emitDecoratorMetadata: program.config.get("decoratorsMetadata", false),
+    strict: false,
+    skipLibCheck: true,
+    downlevelIteration: true,
+    esModuleInterop: true,
+    module: format === "esm" ? 7 : 1,
+    moduleResolution: 2, // NodeJs
+  };
+
+  if ("text" in footerBanner) {
+    switch (footerBanner.loader) {
+      case "typescript":
+        return await program.tsProgram.parseFile({
+          filePath: "footer-or-banner.ts",
+          fileContent: footerBanner.text,
+          compilerOptions: tsOptions,
+        });
+      case "esbuild":
+        return await esbuild
+          .transform(footerBanner.text, {
+            target: program.config.get("target"),
+            loader: "ts",
+            format,
+          })
+          .then((r) => r.code);
+      default:
+        return footerBanner.text;
+    }
+  } else {
+    const srcdir = program.config.get("srcDir");
+    const fileContent = await readFile(
+      path.resolve(srcdir, footerBanner.file),
+      "utf-8"
+    );
+
+    switch (footerBanner.loader) {
+      case "copy":
+        return fileContent;
+      case "typescript":
+        return await program.tsProgram.parseFile({
+          filePath: path.basename(footerBanner.file),
+          fileContent: fileContent,
+          compilerOptions: tsOptions,
+        });
+      default:
+        return await esbuild
+          .transform(fileContent, {
+            target: program.config.get("target"),
+            loader: "ts",
+            format,
+          })
+          .then((r) => r.code);
+    }
+  }
+};


### PR DESCRIPTION
Added two new config options: `footer` and `banner`. Those can be used to inject code or comments to the top or bottom of selected output files. Both options can be provided with either a string or a filename with the contents to add to the output. Additionally provided banner and footers can be parsed using the specified loader ("copy", "esbuild" and "typescript"). By default string are loaded using "copy", and files are loaded using "esbuild".